### PR TITLE
Add test for flood fill in bomb

### DIFF
--- a/test/cell_test.rb
+++ b/test/cell_test.rb
@@ -114,6 +114,16 @@ class CellTest < Test::Unit::TestCase
     assert_false mock_grid.cells[1][0].revealed
   end
 
+  def test_flood_fill_on_bomb
+    mock_grid = generate_3x3_mock_grid
+
+    # Reveal cell with 0 (flood fill all except bomb)
+    mock_grid.cells[0][0].reveal(mock_grid.cells, 3)
+
+    assert_false mock_grid.cells[0][1].revealed
+    assert_false mock_grid.cells[1][0].revealed
+  end
+
   def test_symbol
     bomb = Cell.new(1, 1, true)
     assert_equal bomb.symbol, 'X'


### PR DESCRIPTION
## Description

Added test for flood filling when a bomb is opened

This PR is intended to avoid errors that may be induced with future changes in the current funcionalities

## Requirements

None.

## Additional changes

None.
